### PR TITLE
プロトタイプ編集・削除機能の実装

### DIFF
--- a/app/assets/stylesheets/protospace.css.scss
+++ b/app/assets/stylesheets/protospace.css.scss
@@ -625,3 +625,10 @@ body {
   height: 10px;
   text-align: center;
 }
+
+/*-- dropdown --------------------------------------------- */
+.drop_menu_location {
+    position: absolute;
+    top: 10px;
+    left: 20px;
+}

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,5 @@
 class PrototypesController < ApplicationController
-  before_action :set_prototype, only: :show
+  before_action :set_prototype, only: [:show, :destroy, :update, :edit]
 
   def index
     @prototypes = Prototype.includes(:user)
@@ -25,10 +25,32 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def edit
+
+  end
+
+  def update
+    if @prototype.update(update_params)
+      flash[:success] = "Prototype was successfully updated."
+      redirect_to root_path
+    end
+  end
+
+  def destroy
+    if @prototype.destroy
+      flash[:success] = "Prototype was successfully deleted."
+      redirect_to root_path
+    end
+  end
+
   private
 
   def create_params
     params.require(:prototype).permit(:title, :catchcopy, :concept, capturedimages_attributes: [:prototype_id, :image, :role]).merge(user_id: current_user.id)
+  end
+
+  def update_params
+    params.require(:prototype).permit(:title, :catchcopy, :concept, capturedimages_attributes: [:id, :image, :role])
   end
 
   def set_prototype

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -30,16 +30,24 @@ class PrototypesController < ApplicationController
   end
 
   def update
-    if @prototype.update(update_params)
-      flash[:success] = "Prototype was successfully updated."
-      redirect_to root_path
+    if @prototype.user_id == current_user.id
+        @prototype.update(update_params)
+        flash[:success] = "Prototype was successfully updated."
+        redirect_to root_path
+    else
+        flash[:error] = @prototype.errors.full_messages
+        redirect_to edit_prototype_path
     end
   end
 
   def destroy
-    if @prototype.destroy
-      flash[:success] = "Prototype was successfully deleted."
-      redirect_to root_path
+    if @prototype.user_id == current_user.id
+        @prototype.destroy
+        flash[:success] = "Prototype was successfully deleted."
+        redirect_to root_path
+    else
+        flash[:error] = @prototype.errors.full_messages
+        redirect_to root_path
     end
   end
 

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -2,7 +2,7 @@ class Prototype < ActiveRecord::Base
   belongs_to :user
   has_many :capturedimages, dependent: :delete_all
 
-  accepts_nested_attributes_for :capturedimages
+  accepts_nested_attributes_for :capturedimages, allow_destroy: true
 
   validates_presence_of :title, :catchcopy, :concept
 end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,6 +1,6 @@
 class Prototype < ActiveRecord::Base
   belongs_to :user
-  has_many :capturedimages
+  has_many :capturedimages, dependent: :delete_all
 
   accepts_nested_attributes_for :capturedimages
 

--- a/app/views/layouts/_prototypes.html.haml
+++ b/app/views/layouts/_prototypes.html.haml
@@ -1,4 +1,12 @@
 .col-sm-4.col-md-3.proto-content
+  - if prototypes.user_id == current_user.id
+    .dropdown.drop_menu_location
+      %button.btn.btn-default.dropdown-toggle{ type: "button", "data-toggle" => "dropdown", id: "dropdownMenu"}
+        ACTION
+      %ul.dropdown-menu{ area: { labelledby: "dropdownMenu1" } }
+        %li
+          = link_to "Delete", prototype_path(prototypes), method: :delete
+          = link_to "Edit", edit_prototype_path(prototypes)
   .thumbnail
     = link_to prototype_path(prototypes) do
       = image_tag prototypes.capturedimages.first.image

--- a/app/views/prototypes/edit.html.haml
+++ b/app/views/prototypes/edit.html.haml
@@ -1,0 +1,42 @@
+= form_for(@prototype, html:{class: 'container proto-new'}) do |f|
+  .col-md-8.col-md-offset-2
+    %header.row.user-nav.row
+      .col-md-12
+        = f.text_field :title, class: "proto-new-title", placeholder: "Title"
+    .row
+      .col-md-12
+        .cover-image-upload
+          = f.fields_for :capturedimages, @prototype.capturedimages.first do |picture|
+            = picture.file_field :image
+            = picture.hidden_field :role, value: :main
+      .col-md-12
+        %ul.proto-sub-list.list-group
+          %li.list-group-item.col-md-4
+            = f.fields_for :capturedimages, @prototype.capturedimages.sub.first do |picture|
+              .image-upload
+                = picture.file_field :image
+                = picture.hidden_field :role, value: :sub
+          %li.list-group-item.col-md-4
+            = f.fields_for :capturedimages, @prototype.capturedimages.sub.second do |picture|
+              .image-upload
+                = picture.file_field :image
+                = picture.hidden_field :role, value: :sub
+          %li.list-group-item.col-md-4
+            .image-upload-plus
+              %span +
+    .row.proto-description
+      .col-md-12
+        = f.text_field :catchcopy, placeholder: "Catch Copy"
+      .col-md-12
+        = f.text_area :concept, placeholder: "Concept", cols: "30", rows: "4"
+      .col-md-12
+        %h4 Tag List
+        .row
+          .col-md-3
+            %input{type: "text", placeholder: "Web Design"}/
+          .col-md-3
+            %input{type: "text", placeholder: "UI"}/
+          .col-md-3
+            %input{type: "text", placeholder: "Application"}/
+    .row.text-center.proto-btn
+      = f.submit :commit, class: 'btn btn-lg btn-primary btn-block', type: "submit", value: "Publish"


### PR DESCRIPTION
# WHAT

・prototypes_controllerにアクションの追加
・protospace.css.scssにドロップダウンのデザインを記述
・編集画面、edit.html.hamlの作成
・prototypeが削除されたら、capturedimagesも削除されるように、prototype.rbを修正
# WHY

・投稿したプロトタイプを編集・削除できるようにし、最新の状態をユーザーへ知らせるため。
